### PR TITLE
Search regex breaks on Nomad

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 - name: Lookup the SHA sums file
   set_fact:
         hashicorp_app_sha_lines: "{{ lookup('url', hashicorp_app_shafile_url, split_lines=False) }}"
-        hashicorp_app_regex_search: "([a-zA-Z0-9]*)\\s+{{ hashicorp_app_name }}_[0-9\\.]+_linux_amd64\\.zip"
+        hashicorp_app_regex_search: "([a-zA-Z0-9]*)\\s+(\\.?/?){{ hashicorp_app_name }}_[0-9\\.]+_linux_amd64\\.zip"
 
 - name: Filter the sha256 sum
   set_fact:


### PR DESCRIPTION
Really excellent role! Saved me a bunch of time doing something similar. Ran into an issue with checksum format when installing Nomad, though.

Error:
```
TASK [nioniosfr.hashicorp_app : Download hashicorp_package] *********************
fatal: [localhost]: FAILED! => {
"changed": false,
"checksum_dest": null,
"checksum_src": null,
"dest": "/tmp/nomad_0.10.0.zip",
"elapsed": 0,
"msg": "The checksum format is invalid",
"url": "https://releases.hashicorp.com/nomad/0.10.0/nomad_0.10.0_linux_amd64.zip"
}
```

Playbook:
```
- name: Install Hashi
  hosts: all
  become: yes
  roles:
    - role: nioniosfr.hashicorp_app
      vars:
        hashicorp_app_name: "nomad"
        hashicorp_app_version: "0.10.0"
        hashicorp_app_binary_dest: "/usr/local/bin"
        hashicorp_app_configure_system_path: no
        hashicorp_app_cleanup_after: yes

    - role: nioniosfr.hashicorp_app
      vars:
        hashicorp_app_name: "terraform"
        hashicorp_app_version: "0.12.12"
        hashicorp_app_binary_dest: "/usr/local/bin"
        hashicorp_app_configure_system_path: no
        hashicorp_app_cleanup_after: yes
```

Found that Nomad's checksum files have a slight difference in their file name convention than the other Hashi tools.

[Nomad SHA256](https://releases.hashicorp.com/nomad/0.10.0/nomad_0.10.0_SHA256SUMS):
```
6b3bc96efdfec6337acb8f1bac1c46a87eff6d4a54dcb5b0e16b81c0ce9fca45  ./nomad_0.10.0_linux_amd64.zip
```
[Terraform SHA256](https://releases.hashicorp.com/terraform/0.12.12/terraform_0.12.12_SHA256SUMS):
```
67bc7a49c0946ad48b14cc6e95482fdd3e7e9f7dc6811f4ce6ff531fc565bd3a  terraform_0.12.12_linux_amd64.zip
```
The fix was just a very small tweak to the search regex, but it fixed the problem for me. Cheers!
